### PR TITLE
Fastparse implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,3 +103,5 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "com.chuusai" %%% "shapeless" % "2.3.3"
 )
+
+libraryDependencies += "com.lihaoyi" %%% "fastparse" % "1.0.0"

--- a/src/main/scala/com/github/aborg0/caseyclassy/FastParseParseCaseClass.scala
+++ b/src/main/scala/com/github/aborg0/caseyclassy/FastParseParseCaseClass.scala
@@ -1,0 +1,75 @@
+package com.github.aborg0.caseyclassy
+
+import fastparse.all._
+import java.time.{LocalDate, LocalTime}
+
+import fastparse.all
+import shapeless._
+
+import scala.reflect.runtime.universe._
+
+private[caseyclassy] trait FPGenericImplementations {
+  implicit def longParse: FastParseParse[Long] = () => P("-".? ~ CharIn('0' to '9').rep(1)).!.map(_.toLong)
+
+  implicit def intParse: FastParseParse[Int] = () => P("-".? ~ CharIn('0' to '9').rep(1)).!.map(_.toInt)
+
+  implicit def shortParse: FastParseParse[Short] = () => P("-".? ~ CharIn('0' to '9').rep(1)).!.map(_.toShort)
+
+  implicit def byteParse: FastParseParse[Byte] = () => P("-".? ~ CharIn('0' to '9').rep(1)).!.map(_.toByte)
+
+  implicit def booleanParse: FastParseParse[Boolean] = () => P("true" | "false").!.map(_.toBoolean)
+
+  implicit def doubleParse: FastParseParse[Double] = () => numeric.!.map(_.toDouble)
+
+  implicit def floatParse: FastParseParse[Float] = () => numeric.!.map(_.toFloat)
+
+  private[this] def numeric: all.Parser[String] = P("NaN" | "-".? ~ "Infinity" |
+    ("-".? ~ CharIn('0' to '9').rep(1) ~
+      ("." ~/ CharIn('0' to '9').rep(1)).? ~
+      (CharIn("eE") ~/ CharIn("+-").? ~/ CharIn('0' to '9').rep(1)).?)).!
+
+  implicit def parseHNil: FastParseParse[HNil] = () => Pass.map(_ => HNil)
+
+  implicit def parseCNil: FastParseParse[CNil] = () => Fail.log("CNil")
+
+  implicit def parseProduct[Head, Tail <: HList](implicit headParse: Lazy[FastParseParse[Head]], tailParse: Lazy[FastParseParse[Tail]]): FastParseParse[Head :: Tail] = () => (headParse.value.parser() ~ ",".? ~ tailParse.value.parser()).map { case (h, t) => h :: t }
+
+  implicit def parseCoproduct[Head: TypeTag, Tail <: Coproduct](implicit headParse: Lazy[FastParseParse[Head]], tailParse: Lazy[FastParseParse[Tail]]): FastParseParse[Head :+: Tail] = () => headParse.value.parser().map(Inl(_)) | tailParse.value.parser().map(Inr(_))
+
+  implicit def generic[A: TypeTag, R](implicit gen: Generic.Aux[A, R], argParse: FastParseParse[R]): FastParseParse[A] = () => {
+    val typeKind = implicitly[TypeTag[A]]
+    if (typeKind.tpe.typeSymbol.isAbstract /* Approximation of sealed trait */ ) argParse.parser().map(gen.from) else {
+      val name = typeKind.tpe.typeSymbol.name.toString
+      if (name.startsWith("Tuple")) P("(" ~/ argParse.parser() ~ ")").map(gen.from) else P(name ~ (("(" ~/ argParse.parser() ~ ")") | argParse.parser())).map(gen.from)
+    }
+  }
+}
+
+case object FastParseParseCaseClass extends ParseCaseClass with FPGenericImplementations {
+
+  override def to[A](input: String)(implicit parse: Lazy[Parse[A]]): A = {
+    parse.value.parse(input)
+  }
+
+  def apply[A](implicit p: Lazy[FastParseParse[A]]): FastParseParse[A] = p.value
+
+  //region Custom overrides of special types
+  implicit def stringParse: FastParseParse[String] = () => P(CharsWhile(c => c != ',' && c != ')').!) | P("").!
+
+  implicit def timeParse: FastParseParse[LocalTime] = () => P(
+    CharIn('0' to '9').rep(2, "", 2) ~ ":" ~
+      CharIn('0' to '9').rep(2, "", 2) ~
+      (":" ~/ CharIn('0' to '9').rep(2, "", 2) ~
+        ("." ~/ CharIn('0' to '9').rep(1)).?).?).!.map(LocalTime.parse(_))
+
+  implicit def dateParse: FastParseParse[LocalDate] = () => P(CharIn('0' to '9').rep(4, "", 4) ~ "-" ~ CharIn('0' to '9').rep(1, "", 2) ~ "-" ~ CharIn('0' to '9').rep(1, "", 2)).!.map(LocalDate.parse(_))
+
+  implicit def seqConverter[A](implicit parseA: FastParseParse[A]): FastParseParse[Seq[A]] = () => P(("WrappedArray" | "List" | "Vector") ~ "(" ~/ parseA.parser().rep(sep = ", ") ~ ")")
+  //endregion
+}
+
+trait FastParseParse[A] extends Parse[A] {
+  protected[caseyclassy] def parser(): Parser[A]
+
+  override def parse(input: String): A = parser().parse(input).fold((p, i, e) => throw new IllegalArgumentException(s"Expected: $p at position: $i"), (a, i) => a)
+}

--- a/src/main/scala/com/github/aborg0/caseyclassy/FastParseParseCaseClass.scala
+++ b/src/main/scala/com/github/aborg0/caseyclassy/FastParseParseCaseClass.scala
@@ -3,44 +3,52 @@ package com.github.aborg0.caseyclassy
 import fastparse.all._
 import java.time.{LocalDate, LocalTime}
 
-import fastparse.all
 import shapeless._
 
 import scala.reflect.runtime.universe._
 
 private[caseyclassy] trait FPGenericImplementations {
-  implicit def longParse: FastParseParse[Long] = () => P("-".? ~ CharIn('0' to '9').rep(1)).!.map(_.toLong)
-
-  implicit def intParse: FastParseParse[Int] = () => P("-".? ~ CharIn('0' to '9').rep(1)).!.map(_.toInt)
-
-  implicit def shortParse: FastParseParse[Short] = () => P("-".? ~ CharIn('0' to '9').rep(1)).!.map(_.toShort)
-
-  implicit def byteParse: FastParseParse[Byte] = () => P("-".? ~ CharIn('0' to '9').rep(1)).!.map(_.toByte)
-
   implicit def booleanParse: FastParseParse[Boolean] = () => P("true" | "false").!.map(_.toBoolean)
+
+  private[this] def integral: Parser[String] = P("-".? ~ CharIn('0' to '9').rep(1)).!
+
+  private[this] def numeric: Parser[String] = P("NaN" | "-".? ~ "Infinity" |
+    ("-".? ~ CharIn('0' to '9').rep(1) ~
+      ("." ~/ CharIn('0' to '9').rep(1)).? ~
+      (CharIn("eE") ~/ CharIn("+-").? ~/ CharIn('0' to '9').rep(1)).?)).!
+
+  implicit def longParse: FastParseParse[Long] = () => integral.map(_.toLong)
+
+  implicit def intParse: FastParseParse[Int] = () => integral.map(_.toInt)
+
+  implicit def shortParse: FastParseParse[Short] = () => integral.map(_.toShort)
+
+  implicit def byteParse: FastParseParse[Byte] = () => integral.map(_.toByte)
 
   implicit def doubleParse: FastParseParse[Double] = () => numeric.!.map(_.toDouble)
 
   implicit def floatParse: FastParseParse[Float] = () => numeric.!.map(_.toFloat)
 
-  private[this] def numeric: all.Parser[String] = P("NaN" | "-".? ~ "Infinity" |
-    ("-".? ~ CharIn('0' to '9').rep(1) ~
-      ("." ~/ CharIn('0' to '9').rep(1)).? ~
-      (CharIn("eE") ~/ CharIn("+-").? ~/ CharIn('0' to '9').rep(1)).?)).!
-
   implicit def parseHNil: FastParseParse[HNil] = () => Pass.map(_ => HNil)
 
   implicit def parseCNil: FastParseParse[CNil] = () => Fail.log("CNil")
 
-  implicit def parseProduct[Head, Tail <: HList](implicit headParse: Lazy[FastParseParse[Head]], tailParse: Lazy[FastParseParse[Tail]]): FastParseParse[Head :: Tail] = () => (headParse.value.parser() ~ ",".? ~ tailParse.value.parser()).map { case (h, t) => h :: t }
+  implicit def parseProduct[Head, Tail <: HList](implicit headParse: Lazy[FastParseParse[Head]],
+                                                 tailParse: Lazy[FastParseParse[Tail]]): FastParseParse[Head :: Tail] =
+    () => (headParse.value.parser() ~ ",".? ~ tailParse.value.parser()).map { case (h, t) => h :: t }
 
-  implicit def parseCoproduct[Head: TypeTag, Tail <: Coproduct](implicit headParse: Lazy[FastParseParse[Head]], tailParse: Lazy[FastParseParse[Tail]]): FastParseParse[Head :+: Tail] = () => headParse.value.parser().map(Inl(_)) | tailParse.value.parser().map(Inr(_))
+  implicit def parseCoproduct[Head, Tail <: Coproduct](implicit headParse: Lazy[FastParseParse[Head]],
+                                                                tailParse: Lazy[FastParseParse[Tail]]): FastParseParse[Head :+: Tail] =
+    () => headParse.value.parser().map(Inl(_)) | tailParse.value.parser().map(Inr(_))
 
   implicit def generic[A: TypeTag, R](implicit gen: Generic.Aux[A, R], argParse: FastParseParse[R]): FastParseParse[A] = () => {
     val typeKind = implicitly[TypeTag[A]]
     if (typeKind.tpe.typeSymbol.isAbstract /* Approximation of sealed trait */ ) argParse.parser().map(gen.from) else {
       val name = typeKind.tpe.typeSymbol.name.toString
-      if (name.startsWith("Tuple")) P("(" ~/ argParse.parser() ~ ")").map(gen.from) else P(name ~ (("(" ~/ argParse.parser() ~ ")") | argParse.parser())).map(gen.from)
+      if (name.startsWith("Tuple"))
+        P("(" ~/ argParse.parser() ~ ")").map(gen.from)
+      else
+        P(name ~ (("(" ~/ argParse.parser() ~ ")") | argParse.parser())).map(gen.from)
     }
   }
 }
@@ -54,7 +62,8 @@ case object FastParseParseCaseClass extends ParseCaseClass with FPGenericImpleme
   def apply[A](implicit p: Lazy[FastParseParse[A]]): FastParseParse[A] = p.value
 
   //region Custom overrides of special types
-  implicit def stringParse: FastParseParse[String] = () => P(CharsWhile(c => c != ',' && c != ')').!) | P("").!
+  implicit def stringParse: FastParseParse[String] = () =>
+    P(CharsWhile(c => c != ',' && c != ')').!) | P("").!
 
   implicit def timeParse: FastParseParse[LocalTime] = () => P(
     CharIn('0' to '9').rep(2, "", 2) ~ ":" ~
@@ -62,14 +71,19 @@ case object FastParseParseCaseClass extends ParseCaseClass with FPGenericImpleme
       (":" ~/ CharIn('0' to '9').rep(2, "", 2) ~
         ("." ~/ CharIn('0' to '9').rep(1)).?).?).!.map(LocalTime.parse(_))
 
-  implicit def dateParse: FastParseParse[LocalDate] = () => P(CharIn('0' to '9').rep(4, "", 4) ~ "-" ~ CharIn('0' to '9').rep(1, "", 2) ~ "-" ~ CharIn('0' to '9').rep(1, "", 2)).!.map(LocalDate.parse(_))
+  implicit def dateParse: FastParseParse[LocalDate] = () =>
+    P(CharIn('0' to '9').rep(4, "", 4) ~ "-" ~
+      CharIn('0' to '9').rep(1, "", 2) ~ "-" ~
+      CharIn('0' to '9').rep(1, "", 2)).!.map(LocalDate.parse(_))
 
-  implicit def seqConverter[A](implicit parseA: FastParseParse[A]): FastParseParse[Seq[A]] = () => P(("WrappedArray" | "List" | "Vector") ~ "(" ~/ parseA.parser().rep(sep = ", ") ~ ")")
+  implicit def seqConverter[A](implicit parseA: FastParseParse[A]): FastParseParse[Seq[A]] = () =>
+    P(("WrappedArray" | "List" | "Vector") ~ "(" ~/ parseA.parser().rep(sep = ", ") ~ ")")
   //endregion
 }
 
 trait FastParseParse[A] extends Parse[A] {
   protected[caseyclassy] def parser(): Parser[A]
 
-  override def parse(input: String): A = parser().parse(input).fold((p, i, e) => throw new IllegalArgumentException(s"Expected: $p at position: $i"), (a, i) => a)
+  override def parse(input: String): A = parser().parse(input).fold((p, i, e) =>
+    throw new IllegalArgumentException(s"Expected: $p at position: $i"), (a, i) => a)
 }

--- a/src/main/scala/com/github/aborg0/caseyclassy/ParseCaseClass.scala
+++ b/src/main/scala/com/github/aborg0/caseyclassy/ParseCaseClass.scala
@@ -3,7 +3,7 @@ package com.github.aborg0.caseyclassy
 import shapeless.Lazy
 
 trait ParseCaseClass {
-  def to[A <: AnyRef](input: String)(implicit parse: Lazy[Parse[A]]): A
+  def to[A /*<: AnyRef*/](input: String)(implicit parse: Lazy[Parse[A]]): A
 }
 
 trait Parse[A] {

--- a/src/main/scala/com/github/aborg0/caseyclassy/RegexParseCaseClass.scala
+++ b/src/main/scala/com/github/aborg0/caseyclassy/RegexParseCaseClass.scala
@@ -126,7 +126,7 @@ private[caseyclassy] trait GenericImplementations {
 
 case object RegexParseCaseClass extends ParseCaseClass with GenericImplementations {
 
-  override def to[A <: AnyRef](input: String)(implicit parse: Lazy[Parse[A]]): A = {
+  override def to[A/* <: AnyRef*/](input: String)(implicit parse: Lazy[Parse[A]]): A = {
     parse.value.parse(input)
   }
 

--- a/src/main/tut/Examples.md
+++ b/src/main/tut/Examples.md
@@ -1,14 +1,14 @@
 # Examples
 
 ## Intro
-There might be multiple implementations of ParseCaseClass, currently only RegexParseCaseClass is supported:
+There might be multiple implementations of `ParseCaseClass`, currently only `RegexParseCaseClass` and `FastParseParseCaseClass` are supported, but only one should be used in a scope (in this case `RegexParseCaseClass`):
 ```tut:silent
 import com.github.aborg0.caseyclassy.RegexParseCaseClass
 import com.github.aborg0.caseyclassy.RegexParseCaseClass._
 import java.time.{LocalDate, LocalTime}
 import shapeless._
 ```
-It might possible to parse simple values, like `Boolean`, `Byte`, `Short`, `Int`, `Long`, `Float`, `Double`, `LocalTime`, `LocalDate` and `String`s without comma (`,`) or closing parenthesis (`)`), but this library was designed to parse toString of algebraic data types (products -case classes, tuples- and coproducts) of them. Also some `Seq`s (`List`, `Vector`, `WrappedArray` (for varargs)) are supported.
+It is possible to parse simple values, like `Boolean`, `Byte`, `Short`, `Int`, `Long`, `Float`, `Double`, `LocalTime`, `LocalDate` and `String`s without comma (`,`) or closing parenthesis (`)`), but this library was designed to parse toString of algebraic data types (products -case classes, tuples- and coproducts) of them. Also some `Seq`s (`List`, `Vector`, `WrappedArray` (for varargs)) are supported.
 
 ### Simple primitives
 
@@ -93,3 +93,92 @@ RegexParseCaseClass.to[Option[Either[String, Seq[Boolean]]]]("Some(Left(List(fal
 ```
 
 Please note that the `String` part contains only till the first `,` (`List(false`) within and no error is reported currently.
+
+# Same content with FastParse (`FastParseParseCaseClass`)
+
+```tut:silent:reset
+```
+
+## Intro
+There might be multiple implementations of `ParseCaseClass`, currently only `RegexParseCaseClass` and `FastParseParseCaseClass` are supported, but only one should be used in a scope (in this case `FastParseParseCaseClass`):
+```tut:silent
+import com.github.aborg0.caseyclassy.FastParseParseCaseClass
+import com.github.aborg0.caseyclassy.FastParseParseCaseClass._
+import java.time.{LocalDate, LocalTime}
+import shapeless._
+```
+It is possible to parse simple values, like `Boolean`, `Byte`, `Short`, `Int`, `Long`, `Float`, `Double`, `LocalTime`, `LocalDate` and `String`s without comma (`,`) or closing parenthesis (`)`), but this library was designed to parse toString of algebraic data types (products -case classes, tuples- and coproducts) of them. Also some `Seq`s (`List`, `Vector`, `WrappedArray` (for varargs)) are supported.
+
+### Simple primitives
+
+`LocalDate`:
+
+```tut
+val date: LocalDate = FastParseParseCaseClass.to[LocalDate]("2018-04-01")
+```
+
+or it is also possible to create a parser and reuse it:
+
+```tut
+val dateParser = FastParseParseCaseClass[LocalDate]
+dateParser.parse("2018-04-01")
+dateParser.parse("2018-04-22")
+```
+
+Tuple2 of `String` and `Int`:
+
+```tut
+FastParseParseCaseClass.to[(String, Int)]("(   hello,4)")
+```
+
+Or in the other order:
+
+```tut
+val (i, s) = FastParseParseCaseClass.to[(Int, String)]("(4,   hello)")
+```
+
+The error messages are not very good:
+
+```tut:fail
+val dateTuple1 = FastParseParseCaseClass.to[Tuple1[LocalDate]]("2018-04-01")
+```
+
+## Algebraic data types
+
+With help of shapeless the following constructs are supported:
+- case classes
+- case objects
+- sealed hierarchies
+- tuples
+- a few `Seq` types
+
+### Case classes
+
+```tut
+case class Example(a: Int, s: String)
+FastParseParseCaseClass.to[Example]("Example(-3, Hello)")
+```
+
+```tut
+case object Dot
+
+FastParseParseCaseClass.to[Dot.type]("Dot")
+```
+
+### Sealed hierarchies
+
+#### Either
+
+```tut
+FastParseParseCaseClass.to[Either[Short, Boolean]]("Left(-1111)")
+FastParseParseCaseClass.to[Either[Short, Boolean]]("Right(false)")
+```
+
+#### Option
+
+```tut
+FastParseParseCaseClass.to[Option[Option[Int]]]("Some(None)")
+FastParseParseCaseClass.to[Option[Option[Int]]]("None")
+FastParseParseCaseClass.to[Option[Either[String, Seq[Boolean]]]]("Some(Right(List()))")
+FastParseParseCaseClass.to[Option[Either[String, Seq[Boolean]]]]("Some(Right(List(false, true)))")
+```

--- a/src/test/scala/com/github/aborg0/caseyclassy/FPSimpleTests.scala
+++ b/src/test/scala/com/github/aborg0/caseyclassy/FPSimpleTests.scala
@@ -3,16 +3,14 @@ package com.github.aborg0.caseyclassy
 import java.time.LocalDate
 
 import com.github.aborg0.caseyclassy.example.{SimpleBoolean, SimpleDouble, SimpleInt, SimpleObject}
-import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.FlatSpec
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1, TableFor2}
 
-class SimpleTests extends FlatSpec with TableDrivenPropertyChecks {
-  val implementations: TableFor1[ParseCaseClass] = Table("implementation", RegexParseCaseClass)
+class FPSimpleTests extends FlatSpec with TableDrivenPropertyChecks {
+  val implementations: TableFor1[ParseCaseClass] = Table("implementation", FastParseParseCaseClass)
 
-  behavior of "ParseCaseClass for simple cases"
-
-  import RegexParseCaseClass._
+  behavior of "FastParseParseCaseClass for simple cases"
+  import FastParseParseCaseClass._
 
   it should "parse SimpleDouble" in {
     val simpleDoubleInputs: TableFor2[ParseCaseClass, SimpleDouble] = Table(
@@ -41,6 +39,16 @@ class SimpleTests extends FlatSpec with TableDrivenPropertyChecks {
     )
     forAll(simpleIntInputs) { (impl: ParseCaseClass, input: SimpleInt) =>
       assert(impl.to[SimpleInt](input.toString) === input)
+    }
+  }
+  it should "parse Int" in {
+    val simpleIntInputs: TableFor2[ParseCaseClass, Int] = Table(
+      ("implementation", "Int"),
+      Seq(1, 0, 2, -5, -10, Int.MaxValue, Int.MinValue).flatMap(i =>
+        implementations.map(impl => impl -> i)): _*
+    )
+    forAll(simpleIntInputs) { (impl: ParseCaseClass, input: Int) =>
+      assert(impl.to[Int](input.toString) === input)
     }
   }
   it should "parse SimpleBoolean" in {
@@ -72,8 +80,8 @@ class SimpleTests extends FlatSpec with TableDrivenPropertyChecks {
     forAll(options) { (impl, input) => assert(impl.to[Tuple1[Option[Int]]](input.toString) === input) }
   }
 
-  "RegexParseCaseClass" should "support reuse" in {
-    val simpleBooleanParser = RegexParseCaseClass[SimpleBoolean]
+  "FastParseParseCaseClass" should "support reuse" in {
+    val simpleBooleanParser = FastParseParseCaseClass[SimpleBoolean]
     assert(simpleBooleanParser.parse("SimpleBoolean(false)") === SimpleBoolean(false))
     assert(simpleBooleanParser.parse("SimpleBoolean(true)") === SimpleBoolean(true))
   }

--- a/src/test/scala/com/github/aborg0/caseyclassy/FPTwoArgsTests.scala
+++ b/src/test/scala/com/github/aborg0/caseyclassy/FPTwoArgsTests.scala
@@ -1,0 +1,70 @@
+package com.github.aborg0.caseyclassy
+
+import java.time.{LocalDate, LocalTime}
+
+import com.github.aborg0.caseyclassy.example.TwoArgsBoolInt
+import org.scalatest.FlatSpec
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1, TableFor2}
+
+class FPTwoArgsTests extends FlatSpec with TableDrivenPropertyChecks {
+  val implementations: TableFor1[ParseCaseClass] = Table("implementation", FastParseParseCaseClass)
+
+  import FastParseParseCaseClass._
+  behavior of "FastParseParseCaseClass for two args cases"
+  it should "parse Tuple2[Int, LocalDate]" in {
+    val intDateInputs: TableFor2[ParseCaseClass, (Int, LocalDate)] = Table(
+      ("implementation", "(Int, LocalDate)"),
+      Seq(1,
+        0,
+        -11111111,
+      ).flatMap(i => Seq(LocalDate.of(1970, 1, 1), LocalDate.of(2000, 12, 31)).map((i, _))).flatMap(tup =>
+        implementations.map(impl => impl -> tup)): _*
+    )
+    forAll(intDateInputs) { (impl: ParseCaseClass, input: (Int, LocalDate)) =>
+      assert(impl.to[(Int, LocalDate)](input.toString) === input)
+    }
+  }
+  it should "parse Tuple2[Byte, LocalTime]" in {
+    val byteTimeInputs: TableFor2[ParseCaseClass, (Byte, LocalTime)] = Table(
+      ("implementation", "(Byte, LocalTime)"),
+      Seq(1.toByte,
+        0.toByte,
+        Byte.MinValue,
+      ).flatMap(i => Seq(LocalTime.of(0, 0, 0), LocalTime.of(23, 59, 59)).map((i, _))).flatMap(tup =>
+        implementations.map(impl => impl -> tup)): _*
+    )
+    forAll(byteTimeInputs) { (impl: ParseCaseClass, input: (Byte, LocalTime)) =>
+      assert(impl.to[(Byte, LocalTime)](input.toString) === input)
+    }
+  }
+  it should "parse Tuple2[Float, Long]" in {
+    val floatLongInputs: TableFor2[ParseCaseClass, (Float, Long)] = Table(
+      ("implementation", "(Float, Long)"),
+      Seq(1l,
+        0l,
+        Long.MinValue,
+        Long.MaxValue,
+      ).flatMap(i => Seq(Float.NegativeInfinity, -3.14159f).map((_, i))).flatMap(tup =>
+        implementations.map(impl => impl -> tup)): _*
+    )
+    forAll(floatLongInputs) { (impl: ParseCaseClass, input: (Float, Long)) =>
+      assert(impl.to[(Float, Long)](input.toString) === input)
+    }
+  }
+
+  it should "parse TwoArgsBoolInt" in {
+    val simpleDoubleInputs: TableFor2[ParseCaseClass, TwoArgsBoolInt] = Table(
+      ("implementation", "TwoArgsBoolInt"),
+      Seq(1,
+        0,
+        -11111111,
+      ).flatMap(i => Seq(true, false).map((i, _))).flatMap(tup =>
+        implementations.map(impl => impl -> TwoArgsBoolInt(tup._2, tup._1))): _*
+    )
+    forAll(simpleDoubleInputs) { (impl: ParseCaseClass, input: TwoArgsBoolInt) =>
+      assert(impl.to[TwoArgsBoolInt](input.toString) === input)
+    }
+
+  }
+
+}

--- a/src/test/scala/com/github/aborg0/caseyclassy/FPVarArgsTests.scala
+++ b/src/test/scala/com/github/aborg0/caseyclassy/FPVarArgsTests.scala
@@ -1,0 +1,104 @@
+package com.github.aborg0.caseyclassy
+
+import com.github.aborg0.caseyclassy.example.{OnlyVarArgs, StringPlusVarArgs}
+import org.scalatest.WordSpec
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1, TableFor2}
+
+class FPVarArgsTests extends WordSpec with TableDrivenPropertyChecks {
+  val implementations: TableFor1[ParseCaseClass] = Table("implementation", FastParseParseCaseClass)
+
+  import FastParseParseCaseClass._
+
+  "ParseCaseClass for variable arity arguments successfully parse" when {
+    "OnlyVarArgs" should {
+      "has empty args" in {
+        forAll(
+          Table(("implementation", "OnlyVarArgs[Int]"), implementations.map(impl => impl -> OnlyVarArgs[Int]()): _*)) {
+          (impl: ParseCaseClass, input: OnlyVarArgs[Int]) =>
+            assert(impl.to[OnlyVarArgs[Int]](input.toString) === input)
+        }
+      }
+      "has one argument" in {
+        val simpleVarArgsInputs: TableFor2[ParseCaseClass, OnlyVarArgs[Int]] = Table(
+          ("implementation", "OnlyVarArgs[Int]"),
+          Seq(1,
+            0,
+            -1,
+            Int.MaxValue,
+            Int.MinValue).flatMap(i =>
+            implementations.map(impl => impl -> OnlyVarArgs[Int](i))): _*
+        )
+        forAll(simpleVarArgsInputs) { (impl: ParseCaseClass, input: OnlyVarArgs[Int]) =>
+          assert(impl.to[OnlyVarArgs[Int]](input.toString) === input)
+        }
+      }
+      "has two arguments" in {
+        val varArgsInputs: TableFor2[ParseCaseClass, OnlyVarArgs[Int]] = Table(
+          ("implementation", "OnlyVarArgs[Int]"),
+          Seq(1,
+            0,
+            -1,
+            Int.MaxValue,
+            Int.MinValue).flatMap(i =>
+            implementations.map(impl => impl -> OnlyVarArgs[Int](i, -i))): _*
+        )
+        forAll(varArgsInputs) { (impl: ParseCaseClass, input: OnlyVarArgs[Int]) =>
+          assert(impl.to[OnlyVarArgs[Int]](input.toString) === input)
+        }
+      }
+      "has three arguments" in {
+        val varArgsInputs: TableFor2[ParseCaseClass, OnlyVarArgs[Int]] = Table(
+          ("implementation", "OnlyVarArgs[Int]"),
+          Seq(1,
+            0,
+            -1,
+            Int.MaxValue,
+            Int.MinValue).flatMap(i =>
+            implementations.map(impl => impl -> OnlyVarArgs[Int](3, i, -i))): _*
+        )
+        forAll(varArgsInputs) { (impl: ParseCaseClass, input: OnlyVarArgs[Int]) =>
+          assert(impl.to[OnlyVarArgs[Int]](input.toString) === input)
+        }
+      }
+    }
+    "StringPlusVarArgs" should {
+      "with String + no arguments" in {
+        val simpleStringPlusVarArgs: TableFor2[ParseCaseClass, StringPlusVarArgs[Short]] = Table(
+          ("implementation", "StringPlusVarArgs[Short]"),
+          Seq("", "Hello", "3").flatMap(s => implementations.map(impl => impl -> StringPlusVarArgs[Short](s))): _*
+        )
+        forAll(simpleStringPlusVarArgs) { (impl: ParseCaseClass, input: StringPlusVarArgs[Short]) =>
+          assert(impl.to[StringPlusVarArgs[Short]](input.toString) === input)
+        }
+      }
+      "with String + one argument" in {
+        val stringPlusVarArgs: TableFor2[ParseCaseClass, StringPlusVarArgs[Short]] = Table(
+          ("implementation", "StringPlusVarArgs[Short]"),
+          Seq("", "Hello", "3").flatMap(s => Seq(1.toShort,
+            0.toShort,
+            (-1).toShort,
+            Short.MaxValue,
+            Short.MinValue).flatMap(i =>
+            implementations.map(impl => impl -> StringPlusVarArgs(s, i)))): _*
+        )
+        forAll(stringPlusVarArgs) { (impl: ParseCaseClass, input: StringPlusVarArgs[Short]) =>
+          assert(impl.to[StringPlusVarArgs[Short]](input.toString) === input)
+        }
+      }
+      "with String + two arguments" in {
+        val stringPlusVarArgs: TableFor2[ParseCaseClass, StringPlusVarArgs[Short]] = Table(
+          ("implementation", "StringPlusVarArgs[Short]"),
+          Seq("", "Hello", "3").flatMap(s => Seq(1.toShort,
+            0.toShort,
+            (-1).toShort,
+            Short.MaxValue,
+            Short.MinValue).flatMap(i =>
+            implementations.map(impl => impl -> StringPlusVarArgs(s, i, 2.toShort)))): _*
+        )
+        forAll(stringPlusVarArgs) { (impl: ParseCaseClass, input: StringPlusVarArgs[Short]) =>
+          assert(impl.to[StringPlusVarArgs[Short]](input.toString) === input)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Below is the output of the updated tut/Examples.md output (check the second part!):

# Examples

## Intro
There might be multiple implementations of `ParseCaseClass`, currently only `RegexParseCaseClass` and `FastParseParseCaseClass` are supported, but only one should be used in a scope (in this case `RegexParseCaseClass`):
```scala
import com.github.aborg0.caseyclassy.RegexParseCaseClass
import com.github.aborg0.caseyclassy.RegexParseCaseClass._
import java.time.{LocalDate, LocalTime}
import shapeless._
```
It is possible to parse simple values, like `Boolean`, `Byte`, `Short`, `Int`, `Long`, `Float`, `Double`, `LocalTime`, `LocalDate` and `String`s without comma (`,`) or closing parenthesis (`)`), but this library was designed to parse toString of algebraic data types (products -case classes, tuples- and coproducts) of them. Also some `Seq`s (`List`, `Vector`, `WrappedArray` (for varargs)) are supported.

### Simple primitives

`LocalDate`:

```scala
scala> val date: LocalDate = RegexParseCaseClass.to[LocalDate]("2018-04-01")
date: java.time.LocalDate = 2018-04-01
```

or it is also possible to create a parser and reuse it:

```scala
scala> val dateParser = RegexParseCaseClass[LocalDate]
dateParser: com.github.aborg0.caseyclassy.RegexParse[java.time.LocalDate] = com.github.aborg0.caseyclassy.RegexParseCaseClass$$anon$11@602995d3

scala> dateParser.parse("2018-04-01")
res0: java.time.LocalDate = 2018-04-01

scala> dateParser.parse("2018-04-22")
res1: java.time.LocalDate = 2018-04-22
```

Tuple2 of `String` and `Int`:

```scala
scala> RegexParseCaseClass.to[(String, Int)]("(   hello,4)")
res2: (String, Int) = ("   hello",4)
```

Or in the other order:

```scala
scala> val (i, s) = RegexParseCaseClass.to[(Int, String)]("(4,   hello)")
i: Int = 4
s: String = "   hello"
```

The error messages are not very good:

```scala
scala> val dateTuple1 = RegexParseCaseClass.to[Tuple1[LocalDate]]("2018-04-01")
java.lang.IllegalArgumentException: |018-04-0| does not start with proper value
  at com.github.aborg0.caseyclassy.CommonRegexParse.$anonfun$parse$6(RegexParseCaseClass.scala:183)
  at scala.Option.getOrElse(Option.scala:121)
  at com.github.aborg0.caseyclassy.CommonRegexParse.parse(RegexParseCaseClass.scala:183)
  at com.github.aborg0.caseyclassy.CommonRegexParse.parse$(RegexParseCaseClass.scala:182)
  at com.github.aborg0.caseyclassy.RegexParseCaseClass$$anon$11.parse(RegexParseCaseClass.scala:145)
  at com.github.aborg0.caseyclassy.GenericImplementations$$anon$2.parse(RegexParseCaseClass.scala:62)
  at com.github.aborg0.caseyclassy.GenericImplementations$$anon$2.parse(RegexParseCaseClass.scala:51)
  at com.github.aborg0.caseyclassy.GenericImplementations$$anon$4.parse(RegexParseCaseClass.scala:114)
  at com.github.aborg0.caseyclassy.RegexParseCaseClass$.to(RegexParseCaseClass.scala:130)
  ... 43 elided
```

## Algebraic data types

With help of shapeless the following constructs are supported:
- case classes
- case objects
- sealed hierarchies
- tuples
- a few `Seq` types

### Case classes

```scala
scala> case class Example(a: Int, s: String)
defined class Example

scala> RegexParseCaseClass.to[Example]("Example(-3, Hello)")
res3: Example = Example(-3, Hello)
```

```scala
scala> case object Dot
defined object Dot

scala> RegexParseCaseClass.to[Dot.type]("Dot")
res4: Dot.type = Dot
```

### Sealed hierarchies

#### Either

```scala
scala> RegexParseCaseClass.to[Either[Short, Boolean]]("Left(-1111)")
res5: Either[Short,Boolean] = Left(-1111)

scala> RegexParseCaseClass.to[Either[Short, Boolean]]("Right(false)")
res6: Either[Short,Boolean] = Right(false)
```

#### Option

```scala
scala> RegexParseCaseClass.to[Option[Option[Int]]]("Some(None)")
res7: Option[Option[Int]] = Some(None)

scala> RegexParseCaseClass.to[Option[Option[Int]]]("None")
res8: Option[Option[Int]] = None

scala> RegexParseCaseClass.to[Option[Either[String, Seq[Boolean]]]]("Some(Right(List()))")
res9: Option[Either[String,Seq[Boolean]]] = Some(Right(Vector()))

scala> RegexParseCaseClass.to[Option[Either[String, Seq[Boolean]]]]("Some(Right(List(false, true)))")
res10: Option[Either[String,Seq[Boolean]]] = Some(Right(Vector(false, true)))
```

# Limitations

`String` handling is not ideal:

```scala
scala> RegexParseCaseClass.to[Option[Either[String, Seq[Boolean]]]]("Some(Left(List(false, true)))")
res11: Option[Either[String,Seq[Boolean]]] = Some(Left(List(false))
```

Please note that the `String` part contains only till the first `,` (`List(false`) within and no error is reported currently.

# Same content with FastParse (`FastParseParseCaseClass`)

```scala
```

## Intro
There might be multiple implementations of `ParseCaseClass`, currently only `RegexParseCaseClass` and `FastParseParseCaseClass` are supported, but only one should be used in a scope (in this case `FastParseParseCaseClass`):
```scala
import com.github.aborg0.caseyclassy.FastParseParseCaseClass
import com.github.aborg0.caseyclassy.FastParseParseCaseClass._
import java.time.{LocalDate, LocalTime}
import shapeless._
```
It is possible to parse simple values, like `Boolean`, `Byte`, `Short`, `Int`, `Long`, `Float`, `Double`, `LocalTime`, `LocalDate` and `String`s without comma (`,`) or closing parenthesis (`)`), but this library was designed to parse toString of algebraic data types (products -case classes, tuples- and coproducts) of them. Also some `Seq`s (`List`, `Vector`, `WrappedArray` (for varargs)) are supported.

### Simple primitives

`LocalDate`:

```scala
scala> val date: LocalDate = FastParseParseCaseClass.to[LocalDate]("2018-04-01")
date: java.time.LocalDate = 2018-04-01
```

or it is also possible to create a parser and reuse it:

```scala
scala> val dateParser = FastParseParseCaseClass[LocalDate]
dateParser: com.github.aborg0.caseyclassy.FastParseParse[java.time.LocalDate] = com.github.aborg0.caseyclassy.FastParseParseCaseClass$$anonfun$dateParse$4@66ec5b45

scala> dateParser.parse("2018-04-01")
res0: java.time.LocalDate = 2018-04-01

scala> dateParser.parse("2018-04-22")
res1: java.time.LocalDate = 2018-04-22
```

Tuple2 of `String` and `Int`:

```scala
scala> FastParseParseCaseClass.to[(String, Int)]("(   hello,4)")
res2: (String, Int) = ("   hello",4)
```

Or in the other order:

```scala
scala> val (i, s) = FastParseParseCaseClass.to[(Int, String)]("(4,   hello)")
i: Int = 4
s: String = "   hello"
```

The error messages are not very good:

```scala
scala> val dateTuple1 = FastParseParseCaseClass.to[Tuple1[LocalDate]]("2018-04-01")
java.lang.IllegalArgumentException: Expected: "(" at position: 0
  at com.github.aborg0.caseyclassy.FastParseParse.$anonfun$parse$1(FastParseParseCaseClass.scala:88)
  at com.github.aborg0.caseyclassy.FastParseParse.$anonfun$parse$1$adapted(FastParseParseCaseClass.scala:87)
  at fastparse.core.Parsed.fold(Parsing.scala:40)
  at fastparse.core.Parsed.fold$(Parsing.scala:38)
  at fastparse.core.Parsed$Failure.fold(Parsing.scala:74)
  at com.github.aborg0.caseyclassy.FastParseParse.parse(FastParseParseCaseClass.scala:88)
  at com.github.aborg0.caseyclassy.FastParseParse.parse$(FastParseParseCaseClass.scala:87)
  at com.github.aborg0.caseyclassy.FPGenericImplementations$$anonfun$generic$10.parse(FastParseParseCaseClass.scala:44)
  at com.github.aborg0.caseyclassy.FastParseParseCaseClass$.to(FastParseParseCaseClass.scala:59)
  ... 43 elided
```

## Algebraic data types

With help of shapeless the following constructs are supported:
- case classes
- case objects
- sealed hierarchies
- tuples
- a few `Seq` types

### Case classes

```scala
scala> case class Example(a: Int, s: String)
defined class Example

scala> FastParseParseCaseClass.to[Example]("Example(-3, Hello)")
res3: Example = Example(-3, Hello)
```

```scala
scala> case object Dot
defined object Dot

scala> FastParseParseCaseClass.to[Dot.type]("Dot")
res4: Dot.type = Dot
```

### Sealed hierarchies

#### Either

```scala
scala> FastParseParseCaseClass.to[Either[Short, Boolean]]("Left(-1111)")
res5: Either[Short,Boolean] = Left(-1111)

scala> FastParseParseCaseClass.to[Either[Short, Boolean]]("Right(false)")
res6: Either[Short,Boolean] = Right(false)
```

#### Option

```scala
scala> FastParseParseCaseClass.to[Option[Option[Int]]]("Some(None)")
res7: Option[Option[Int]] = Some(None)

scala> FastParseParseCaseClass.to[Option[Option[Int]]]("None")
res8: Option[Option[Int]] = None

scala> FastParseParseCaseClass.to[Option[Either[String, Seq[Boolean]]]]("Some(Right(List()))")
res9: Option[Either[String,Seq[Boolean]]] = Some(Right(ArrayBuffer()))

scala> FastParseParseCaseClass.to[Option[Either[String, Seq[Boolean]]]]("Some(Right(List(false, true)))")
res10: Option[Either[String,Seq[Boolean]]] = Some(Right(ArrayBuffer(false, true)))
```

